### PR TITLE
Update web fallback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,26 @@ function FastImageBase({
     forwardedRef,
     ...props
 }) {
-    if (fallback || Platform.OS === 'web') {
+    if (Platform.OS === 'web') {        
+        return (
+            <View ref={forwardedRef}>
+                <Image
+                    {...props}
+                    tintColor={tintColor}
+                    style={style}
+                    source={source}
+                    onLoadStart={onLoadStart}
+                    onProgress={onProgress}
+                    onLoad={onLoad}
+                    onError={onError}
+                    onLoadEnd={onLoadEnd}
+                />
+                {children}
+            </View>
+        )        
+    }
+
+    if (fallback) {
         return (
             <View style={[styles.imageContainer, style]} ref={forwardedRef}>
                 <Image


### PR DESCRIPTION
I honestly think it's cleaner to just return the Image itself, but I'm not sure what sorts of cases I need to handle regarding the forwardedRef since it's on a View for the other cases. As for the children, I feel like it's reasonable to throw an error or something if children are supplied in a web setting

I find that the main problem for _this_ parent View approach is that certain styles don't behave as expected - the main example I've noticed thus far is the zIndex doesn't behave as expected, so I had to wrap that particular FastImage in a `zIndex`'d parent View. I could use some direction moving forward